### PR TITLE
Update co-body@1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "license": "Apache 2.0",
   "dependencies": {
     "oauth2-server": "2.2.2",
-    "co-body": "0.0.1"
+    "co-body": "~1.0.0"
   },
   "devDependencies": {
     "should": "~2.1.1",


### PR DESCRIPTION
`co-body@0.0.1` includes a version of `qs` that has a known vulnerability. This minor update bumps the version of this dependency to `1.0.0` which includes a patched version of `qs` (`>= 1.x`).

@thomseddon note that I've added the tilde operator to this dependency. 
