### PR TITLE
Fix grant `Content-Type` to `application/json`

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,7 @@ OAuthServer.prototype.grant = function () {
   return function *grant(next) {
     // Mock the jsonp method
     this.response.jsonp = function (body) {
-      this.body = JSON.stringify(body);
+      this.body = body;
     };
 
     try {

--- a/test/grant.js
+++ b/test/grant.js
@@ -374,6 +374,33 @@ describe('Grant', function() {
   });
 
   describe('issue access token', function () {
+    it('should return `Content-Type` application/json', function (done) {
+      var app = bootstrap({
+        model: {
+          getClient: function (id, secret, callback) {
+            callback(false, { clientId: 'thom' });
+          },
+          grantTypeAllowed: function (clientId, grantType, callback) {
+            callback(false, true);
+          },
+          getUser: function (uname, pword, callback) {
+            callback(false, { id: 1 });
+          },
+          saveAccessToken: function (token, clientId, expires, user, cb) {
+            cb();
+          }
+        },
+        grants: ['password']
+      });
+
+      request(app.listen())
+        .post('/oauth/token')
+        .set('Content-Type', 'application/x-www-form-urlencoded')
+        .send(validBody)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8', done);
+    });
+
     it('should return an oauth compatible response', function (done) {
       var app = bootstrap({
         model: {


### PR DESCRIPTION
From [RFC6749](https://tools.ietf.org/html/rfc6749#page-43):

>    The parameters are included in the entity-body of the HTTP response
   using the "application/json" media type as defined by [RFC4627].  The
   parameters are serialized into a JavaScript Object Notation (JSON)
   structure by adding each parameter at the highest structure level.
   Parameter names and string values are included as JSON strings.
   Numerical values are included as JSON numbers.  The order of
   parameters does not matter and can vary.

We were returning `test/plain` but the RFC specifies that `application/json` should be returned instead. 