### PR TITLE
Added support for non-header bearer tokens via proxy around Koa request

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "license": "Apache 2.0",
   "dependencies": {
+    "node-proxy": "^1.0.0",
     "oauth2-server": "^2.3.0",
     "thenify": "^3.0.0"
   },


### PR DESCRIPTION
This is a fix for [issue #30](https://github.com/thomseddon/koa-oauth-server/issues/30) - Koa requests return an empty string when a header is missing instead of oauth2-server's expected undefined. This PR wraps authorize requests with a proxy and overrides .get to rectify the issue.

I'm a little ambivalent about adding the node-proxy dependency given that Harmony proxies are supported in recent nodes, but I think its probably the most universally-compatible way to do this.
