### PR TITLE
Authenticate 2nd args must be a Response

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,10 +41,11 @@ KoaOAuthServer.prototype.authenticate = function() {
 
   return function *(next) {
     var request = new Request(this.request);
+    var response = new Response(this.response);
 
     try {
       this.state.oauth = {
-        token: yield server.authenticate(request)
+        token: yield server.authenticate(request, response)
       };
     } catch (e) {
       return handleError.call(this, e);

--- a/test/unit/index_test.js
+++ b/test/unit/index_test.js
@@ -32,10 +32,11 @@ describe('KoaOAuthServer', function() {
       yield request(app.listen())
         .get('/')
         .end();
-
+  
       oauth.server.authenticate.callCount.should.equal(1);
-      oauth.server.authenticate.firstCall.args.should.have.length(1);
+      oauth.server.authenticate.firstCall.args.should.have.length(2);
       oauth.server.authenticate.firstCall.args[0].should.be.an.instanceOf(Request);
+      oauth.server.authenticate.firstCall.args[1].should.be.an.instanceOf(Response);
       oauth.server.authenticate.restore();
     });
   });


### PR DESCRIPTION
When I use `KoaOAuthServer.prototype.authenticate`, I get this error `Invalid argument: response must be an instance of Response`.

With this PR I force authenticate to have an oauth2-server.Response.
