### PR TITLE
Restore ability to handle errors in middleware

### DIFF
--- a/test/integration/index_test.js
+++ b/test/integration/index_test.js
@@ -86,6 +86,30 @@ describe('KoaOAuthServer', function() {
         .get('/')
         .end();
     });
+
+    it('should throw (not emit) an error if `model` is empty when configured with `passthroughErrors`', function* (done) {
+      var oauth = new KoaOAuthServer({ model: {}, passthroughErrors: true });
+
+      app.use(function* (next) {
+        try {
+          yield next;
+        }
+        catch (e) {
+          e.should.be.an.instanceOf(Error);
+          done();
+        }
+      });
+
+      app.use(oauth.authenticate());
+
+      app.on('error', function() {
+        done(new Error('Error got emitted'));
+      });
+
+      yield request(app.listen())
+        .get('/')
+        .end();
+    });
   });
 
   describe('authorize()', function() {
@@ -161,6 +185,30 @@ describe('KoaOAuthServer', function() {
         .post('/')
         .end();
     });
+
+    it('should throw (not emit) an error if `model` is empty when configured with `passthroughErrors`', function* (done) {
+      var oauth = new KoaOAuthServer({ model: {}, passthroughErrors: true });
+
+      app.use(function* (next) {
+        try {
+          yield next;
+        }
+        catch (e) {
+          e.should.be.an.instanceOf(Error);
+          done();
+        }
+      });
+
+      app.use(oauth.authorize());
+
+      app.on('error', function() {
+        done(new Error('Error got emitted'));
+      });
+
+      yield request(app.listen())
+        .get('/')
+        .end();
+    });
   });
 
   describe('token()', function() {
@@ -232,6 +280,30 @@ describe('KoaOAuthServer', function() {
 
       yield request(app.listen())
         .post('/')
+        .end();
+    });
+
+    it('should throw (not emit) an error if `model` is empty when configured with `passthroughErrors`', function* (done) {
+      var oauth = new KoaOAuthServer({ model: {}, passthroughErrors: true });
+
+      app.use(function* (next) {
+        try {
+          yield next;
+        }
+        catch (e) {
+          e.should.be.an.instanceOf(Error);
+          done();
+        }
+      });
+
+      app.use(oauth.token());
+
+      app.on('error', function() {
+        done(new Error('Error got emitted'));
+      });
+
+      yield request(app.listen())
+        .get('/')
         .end();
     });
   });


### PR DESCRIPTION
PR #21 added the ability to configure this library to throw errors, which is more canonical koa as it allows middleware to handle errors. Previously, the library would only emit an error on the `app` event emitter.

PR #31 removed this ability.

This restores the ability to use the more koa-like (and JavaScript-like) error-throwing behavior.
