### PR TITLE
Add an option parameter to the authorize middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ KoaOAuthServer.prototype.authenticate = function() {
  * (See: https://tools.ietf.org/html/rfc6749#section-3.1)
  */
 
-KoaOAuthServer.prototype.authorize = function() {
+KoaOAuthServer.prototype.authorize = function(options) {
   var server = this.server;
 
   return function *(next) {
@@ -71,7 +71,7 @@ KoaOAuthServer.prototype.authorize = function() {
 
     try {
       this.state.oauth = {
-        code: yield server.authorize(request, response)
+        code: yield server.authorize(request, response, options)
       };
 
       handleResponse.call(this, response);

--- a/index.js
+++ b/index.js
@@ -41,10 +41,11 @@ KoaOAuthServer.prototype.authenticate = function() {
 
   return function *(next) {
     var request = new Request(this.request);
+    var response = new Response(this.response);
 
     try {
       this.state.oauth = {
-        token: yield server.authenticate(request)
+        token: yield server.authenticate(request, response)
       };
     } catch (e) {
       return handleError.call(this, e);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "co": "^4.5.1",
-    "oauth2-server": "seegno-forks/node-oauth2-server#enhancement/refactor-project"
+    "oauth2-server": "^3.0.0-b2"
   },
   "devDependencies": {
     "co-mocha": "^1.1.0",


### PR DESCRIPTION
The problem is that when someone tries to use a custom authenticate handler in the oauth-server's authorize middleware, there's no way to pass it through koa-oauth-server. This PR adds the possibility of doing that.
