### PR TITLE
Bugfix ("invalid_argument" error)

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,10 +41,11 @@ KoaOAuthServer.prototype.authenticate = function() {
 
   return function *(next) {
     var request = new Request(this.request);
+    var response = new Response(this.response);
 
     try {
       this.state.oauth = {
-        token: yield server.authenticate(request)
+        token: yield server.authenticate(request, response)
       };
     } catch (e) {
       return handleError.call(this, e);


### PR DESCRIPTION
Using oauth2-server 3.x, app.oauth.authenticate() gives this error:
Invalid argument: `response` must be an instance of Response

The problem was fixed adding the Response object to the function call
