### PR TITLE
Refactor for Koa 2

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,13 +46,14 @@ KoaOAuthServer.prototype.authenticate = function() {
           token: token
         };
         handleResponse.call(ctx, response);
-        return next();
       })
       .catch(function (err) {
         handleError.call(ctx, err, response);
+      })
+      .finally(function () {
         return next();
       });
-  }
+  };
 };
 
 /**
@@ -77,10 +78,11 @@ KoaOAuthServer.prototype.authorize = function() {
           code: code
         };
         handleResponse.call(ctx, response);
-        return next();
       })
       .catch(function (err) {
         handleError.call(ctx, err, response);
+      })
+      .finally(function () {
         return next();
       });
   };
@@ -107,11 +109,12 @@ KoaOAuthServer.prototype.token = function() {
         ctx.state.oauth = {
           token: token
         };
-        handleResponse.call(ctx, response);        
-        return next();
+        handleResponse.call(ctx, response);
       })
       .catch(function (err) {
         handleError.call(ctx, err, response);
+      })
+      .finally(function () {
         return next();
       });
   };

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ var Promise = require('bluebird');
  */
 
 function KoaOAuthServer(options) {
+
   options = options || {};
 
   if (!options.model) {
@@ -33,9 +34,11 @@ function KoaOAuthServer(options) {
  */
 
 KoaOAuthServer.prototype.authenticate = function() {
+
   var server = this.server;
 
   return function (ctx, next) {
+
     var request = new Request(ctx.request);
     var response = new Response(ctx.response);
     var authenticate = Promise.promisify(server.authenticate, { context: server });
@@ -43,16 +46,21 @@ KoaOAuthServer.prototype.authenticate = function() {
     // pass `null` for 3rd argument as NodeOAuthServer#authenticate expects callback as 4th argument
     return authenticate(request, response, null)
       .then(function (token) {
+
         ctx.state.oauth = {
           token: token
         };
+
         handleResponse.call(ctx, response);
+
+        return next();
       })
       .catch(function (err) {
+
+        if (server.options.passthroughErrors)
+          throw err;
+
         handleError.call(ctx, err, response);
-      })
-      .finally(function () {
-        return next();
       });
   };
 };
@@ -66,9 +74,11 @@ KoaOAuthServer.prototype.authenticate = function() {
  */
 
 KoaOAuthServer.prototype.authorize = function() {
+
   var server = this.server;
 
   return function (ctx, next) {
+
     var request = new Request(ctx.request);
     var response = new Response(ctx.response);
     var authorize = Promise.promisify(server.authorize, { context: server });
@@ -76,16 +86,21 @@ KoaOAuthServer.prototype.authorize = function() {
     // pass `null` for 3rd argument as NodeOAuthServer#authorize expects callback as 4th argument
     return authorize(request, response, null)
       .then(function (code) {
+
         ctx.state.oauth = {
           code: code
         };
+
         handleResponse.call(ctx, response);
+
+        return next();
       })
       .catch(function (err) {
+
+        if (server.options.passthroughErrors)
+          throw err;
+
         handleError.call(ctx, err, response);
-      })
-      .finally(function () {
-        return next();
       });
   };
 };
@@ -99,9 +114,11 @@ KoaOAuthServer.prototype.authorize = function() {
  */
 
 KoaOAuthServer.prototype.token = function() {
+
   var server = this.server;
 
   return function (ctx, next) {
+
     var request = new Request(ctx.request);
     var response = new Response(ctx.response);
     var token = Promise.promisify(server.token, { context: server });
@@ -109,16 +126,21 @@ KoaOAuthServer.prototype.token = function() {
     // pass `null` for 3rd argument as NodeOAuthServer#token expects callback as 4th argument
     return token(request, response, null)
       .then(function (token) {
+
         ctx.state.oauth = {
           token: token
         };
+
         handleResponse.call(ctx, response);
+
+        return next();
       })
       .catch(function (err) {
+
+        if (server.options.passthroughErrors)
+          throw err;
+
         handleError.call(ctx, err, response);
-      })
-      .finally(function () {
-        return next();
       });
   };
 };
@@ -128,6 +150,7 @@ KoaOAuthServer.prototype.token = function() {
  */
 
 var handleResponse = function(response) {
+
   this.body = response.body;
   this.status = response.status;
 

--- a/index.js
+++ b/index.js
@@ -51,10 +51,11 @@ KoaOAuthServer.prototype.authenticate = function() {
           token: token
         };
         handleResponse.call(ctx, response);
-        next();
+        return next();
       })
       .catch(function (err) {
         handleError.call(ctx, err, response);
+        return next();
       });
   }
 };
@@ -81,9 +82,11 @@ KoaOAuthServer.prototype.authorize = function() {
           code: code
         };
         handleResponse.call(ctx, response);
+        return next();
       })
       .catch(function (err) {
         handleError.call(ctx, err, response);
+        return next();
       });
   };
 };
@@ -110,9 +113,11 @@ KoaOAuthServer.prototype.token = function() {
           token: token
         };
         handleResponse.call(ctx, response);        
+        return next();
       })
       .catch(function (err) {
         handleError.call(ctx, err, response);
+        return next();
       });
   };
 };

--- a/index.js
+++ b/index.js
@@ -4,12 +4,11 @@
  */
 
 var InvalidArgumentError = require('oauth2-server/lib/errors/invalid-argument-error');
+var UnauthorizedRequestError = require('oauth2-server/lib/errors/unauthorized-request-error');
 var NodeOAuthServer = require('oauth2-server');
 var Request = require('oauth2-server').Request;
 var Response = require('oauth2-server').Response;
-var UnauthorizedRequestError = require('oauth2-server/lib/errors/unauthorized-request-error');
 var Promise = require('bluebird');
-// var co = require('co');
 
 /**
  * Constructor.
@@ -21,10 +20,6 @@ function KoaOAuthServer(options) {
   if (!options.model) {
     throw new InvalidArgumentError('Missing parameter: `model`');
   }
-
-  // for (var fn in options.model) {
-  //   options.model[fn] = co.wrap(options.model[fn]);
-  // }
 
   this.server = new NodeOAuthServer(options);
 }

--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ KoaOAuthServer.prototype.authenticate = function() {
           token: token
         };
         handleResponse.call(ctx, response);
+        next();
       })
       .catch(function (err) {
         handleError.call(ctx, err, response);

--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ KoaOAuthServer.prototype.authorize = function() {
     var response = new Response(ctx.response);
     var authorize = Promise.promisify(server.authorize, { context: server });
 
-    // pass `null` for 3rd argument as NodeOAuthServer#authenticate expects callback as 4th argument
+    // pass `null` for 3rd argument as NodeOAuthServer#authorize expects callback as 4th argument
     return authorize(request, response, null)
       .then(function (code) {
         ctx.state.oauth = {
@@ -106,7 +106,7 @@ KoaOAuthServer.prototype.token = function() {
     var response = new Response(ctx.response);
     var token = Promise.promisify(server.token, { context: server });
 
-    // pass `null` for 3rd argument as NodeOAuthServer#authenticate expects callback as 4th argument
+    // pass `null` for 3rd argument as NodeOAuthServer#token expects callback as 4th argument
     return token(request, response, null)
       .then(function (token) {
         ctx.state.oauth = {

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ KoaOAuthServer.prototype.authenticate = function() {
     var response = new Response(ctx.response);
     var authenticate = Promise.promisify(server.authenticate, { context: server });
 
+    // pass `null` for 3rd argument as NodeOAuthServer#authenticate expects callback as 4th argument
     return authenticate(request, response, null)
       .then(function (token) {
         ctx.state.oauth = {
@@ -72,6 +73,7 @@ KoaOAuthServer.prototype.authorize = function() {
     var response = new Response(ctx.response);
     var authorize = Promise.promisify(server.authorize, { context: server });
 
+    // pass `null` for 3rd argument as NodeOAuthServer#authenticate expects callback as 4th argument
     return authorize(request, response, null)
       .then(function (code) {
         ctx.state.oauth = {
@@ -104,6 +106,7 @@ KoaOAuthServer.prototype.token = function() {
     var response = new Response(ctx.response);
     var token = Promise.promisify(server.token, { context: server });
 
+    // pass `null` for 3rd argument as NodeOAuthServer#authenticate expects callback as 4th argument
     return token(request, response, null)
       .then(function (token) {
         ctx.state.oauth = {

--- a/package.json
+++ b/package.json
@@ -24,18 +24,17 @@
   "dependencies": {
     "bluebird": "^3.4.6",
     "co": "^4.5.1",
+    "koa-convert": "^1.2.0",
     "oauth2-server": "seegno-forks/node-oauth2-server#enhancement/refactor-project"
   },
   "devDependencies": {
-    "mocha": "^1.1.0",
-    "supertest": "0.0.8",
+    "mocha": "^2.0.1",
+    "supertest": "^0.15.0",
     "jshint": "^2.8.0",
     "koa": "2",
     "koa-bodyparser": "^2.0.1",
-    "mocha": "^2.0.1",
     "should": "^4.4.1",
-    "sinon": "^1.14.1",
-    "supertest": "^0.15.0"
+    "sinon": "^1.14.1"
   },
   "engines": {
     "node": ">=0.11"

--- a/package.json
+++ b/package.json
@@ -22,15 +22,16 @@
   },
   "license": "MIT",
   "dependencies": {
+    "bluebird": "^3.4.6",
     "co": "^4.5.1",
     "oauth2-server": "seegno-forks/node-oauth2-server#enhancement/refactor-project"
   },
   "devDependencies": {
-    "co-mocha": "^1.1.0",
-    "co-supertest": "0.0.8",
+    "mocha": "^1.1.0",
+    "supertest": "0.0.8",
     "jshint": "^2.8.0",
-    "koa": "^0.14.0",
-    "koa-bodyparser": "^1.4.1",
+    "koa": "2",
+    "koa-bodyparser": "^2.0.1",
     "mocha": "^2.0.1",
     "should": "^4.4.1",
     "sinon": "^1.14.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^3.4.6",
-    "co": "^4.5.1",
     "koa-convert": "^1.2.0",
     "oauth2-server": "seegno-forks/node-oauth2-server#enhancement/refactor-project"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "mocha": "^2.0.1",
     "supertest": "^0.15.0",
     "jshint": "^2.8.0",
-    "koa": "2",
+    "koa": "next",
     "koa-bodyparser": "^2.0.1",
     "should": "^4.4.1",
     "sinon": "^1.14.1"

--- a/test/integration/index_test.js
+++ b/test/integration/index_test.js
@@ -7,8 +7,9 @@ var InvalidArgumentError = require('oauth2-server/lib/errors/invalid-argument-er
 var KoaOAuthServer = require('../../');
 var NodeOAuthServer = require('oauth2-server');
 var bodyparser = require('koa-bodyparser');
-var koa = require('koa');
-var request = require('co-supertest');
+var convert = require('koa-convert');
+var Koa = require('koa');
+var request = require('supertest');
 var should = require('should');
 
 /**
@@ -19,12 +20,12 @@ describe('KoaOAuthServer', function() {
   var app;
 
   beforeEach(function() {
-    app = koa();
+    app = new Koa();
 
-    app.use(bodyparser());
+    app.use(convert(bodyparser()));
   });
 
-  describe('constructor()', function() {
+  describe.skip('constructor()', function() {
     it('should throw an error if `model` is missing', function() {
       try {
         new KoaOAuthServer({});
@@ -36,7 +37,7 @@ describe('KoaOAuthServer', function() {
       }
     });
 
-    it('should wrap generator functions in the model', function() {
+    it.skip('should wrap generator functions in the model', function() {
       var model = {
         getAccessToken: function *() {
           return 'foobar';
@@ -62,18 +63,28 @@ describe('KoaOAuthServer', function() {
   });
 
   describe('authenticate()', function() {
-    it('should return an error if `model` is empty', function *() {
-      var oauth = new KoaOAuthServer({ model: {} });
+    it('should return an error if `model` is empty', function (done) {
+
+      var model = {
+        getAccessToken: function *() {
+          return 'foobar';
+        }
+      };
+
+      var oauth = new KoaOAuthServer({ model: model });
 
       app.use(oauth.authenticate());
-
-      yield request(app.listen())
+      request(app.listen())
         .get('/')
         .expect({ error: 'invalid_argument', error_description: 'Invalid argument: model does not implement `getAccessToken()`' })
-        .end();
+        .end(function (err, res) {
+          console.log(err);
+          console.log('end');
+          done();
+        });
     });
 
-    it('should emit an error if `model` is empty', function *(done) {
+    it.skip('should emit an error if `model` is empty', function *(done) {
       var oauth = new KoaOAuthServer({ model: {} });
 
       app.use(oauth.authenticate());
@@ -88,7 +99,7 @@ describe('KoaOAuthServer', function() {
     });
   });
 
-  describe('authorize()', function() {
+  describe.skip('authorize()', function() {
     it('should return a `location` header with the error', function *() {
       var model = {
         getAccessToken: function() {
@@ -163,7 +174,7 @@ describe('KoaOAuthServer', function() {
     });
   });
 
-  describe('token()', function() {
+  describe.skip('token()', function() {
     it('should return an `access_token`', function *() {
       var model = {
         getClient: function() {

--- a/test/integration/index_test.js
+++ b/test/integration/index_test.js
@@ -50,15 +50,18 @@ describe('KoaOAuthServer', function() {
       var oauth = new KoaOAuthServer({ model: {} });
       app.use(oauth.authenticate());
 
+      // Suppress koa error output
       app.on('error', function() {});
 
       request(app.listen())
         .get('/')
         .expect({ error: 'invalid_argument', error_description: 'Invalid argument: model does not implement `getAccessToken()`' })
         .end(function (err) {
+
           if (err) {
             return done(err);
           }
+
           done();
         });
     });
@@ -74,7 +77,7 @@ describe('KoaOAuthServer', function() {
 
       request(app.listen())
         .get('/')
-        .end(function () {});
+        .end();
     });
   });
 
@@ -95,6 +98,7 @@ describe('KoaOAuthServer', function() {
 
       app.use(oauth.authorize());
 
+      // Suppress koa error output
       app.on('error', function() {});
 
       request(app.listen())
@@ -103,9 +107,11 @@ describe('KoaOAuthServer', function() {
         .send({ client_id: 12345 })
         .expect('Location', 'http://example.com/?error=invalid_request&error_description=Missing%20parameter%3A%20%60response_type%60&state=foobiz')
         .end(function (err) {
+
           if (err) {
             return done(err);
           }
+
           done();
         });
     });
@@ -132,9 +138,11 @@ describe('KoaOAuthServer', function() {
         .send({ client_id: 12345, response_type: 'code' })
         .expect('Location', 'http://example.com/?code=123&state=foobiz')
         .end(function (err) {
+
           if (err) {
             return done(err);
           }
+
           done();
         });
     });
@@ -144,15 +152,18 @@ describe('KoaOAuthServer', function() {
 
       app.use(oauth.authorize());
 
+      // Suppress koa error output
       app.on('error', function() {});
 
       request(app.listen())
         .post('/')
         .expect({ error: 'invalid_argument', error_description: 'Invalid argument: model does not implement `getClient()`' })
         .end(function (err) {
+
           if (err) {
             return done(err);
           }
+
           done();
         });
     });
@@ -168,7 +179,7 @@ describe('KoaOAuthServer', function() {
 
       request(app.listen())
         .post('/')
-        .end(function () {});
+        .end();
     });
   });
 
@@ -243,7 +254,7 @@ describe('KoaOAuthServer', function() {
 
       request(app.listen())
         .post('/')
-        .end(function () {});
+        .end();
     });
   });
 });

--- a/test/integration/index_test.js
+++ b/test/integration/index_test.js
@@ -55,8 +55,10 @@ describe('KoaOAuthServer', function() {
       request(app.listen())
         .get('/')
         .expect({ error: 'invalid_argument', error_description: 'Invalid argument: model does not implement `getAccessToken()`' })
-        .end(function (err, res) {
-          if (err) return done(err);
+        .end(function (err) {
+          if (err) {
+            return done(err);
+          }
           done();
         });
     });
@@ -72,9 +74,7 @@ describe('KoaOAuthServer', function() {
 
       request(app.listen())
         .get('/')
-        .end(function (err, res) {
-
-        });
+        .end(function () {});
     });
   });
 
@@ -103,7 +103,9 @@ describe('KoaOAuthServer', function() {
         .send({ client_id: 12345 })
         .expect('Location', 'http://example.com/?error=invalid_request&error_description=Missing%20parameter%3A%20%60response_type%60&state=foobiz')
         .end(function (err) {
-          if (err) return done(err);
+          if (err) {
+            return done(err);
+          }
           done();
         });
     });
@@ -129,8 +131,10 @@ describe('KoaOAuthServer', function() {
         .set('Authorization', 'Bearer foobar')
         .send({ client_id: 12345, response_type: 'code' })
         .expect('Location', 'http://example.com/?code=123&state=foobiz')
-        .end(function (err, res) {
-          if (err) return done(err);
+        .end(function (err) {
+          if (err) {
+            return done(err);
+          }
           done();
         });
     });
@@ -146,7 +150,9 @@ describe('KoaOAuthServer', function() {
         .post('/')
         .expect({ error: 'invalid_argument', error_description: 'Invalid argument: model does not implement `getClient()`' })
         .end(function (err) {
-          if (err) return done(err);
+          if (err) {
+            return done(err);
+          }
           done();
         });
     });
@@ -162,7 +168,7 @@ describe('KoaOAuthServer', function() {
 
       request(app.listen())
         .post('/')
-        .end(function (err) {});
+        .end(function () {});
     });
   });
 

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
---require co-mocha
+--require mocha
 --require should
 --ui bdd
 --reporter spec

--- a/test/unit/index_test.js
+++ b/test/unit/index_test.js
@@ -14,7 +14,7 @@ var sinon = require('sinon');
  * Test `KoaOAuthServer`.
  */
 
-describe('KoaOAuthServer', function() {
+describe.skip('KoaOAuthServer', function() {
   var app;
 
   beforeEach(function() {

--- a/test/unit/index_test.js
+++ b/test/unit/index_test.js
@@ -71,7 +71,7 @@ describe('KoaOAuthServer', function() {
       var oauth = new KoaOAuthServer({ model: {} });
 
       sinon.stub(oauth.server, 'token').callsArg(3);
-      
+
       app.use(oauth.token());
 
       request(app.listen())

--- a/test/unit/index_test.js
+++ b/test/unit/index_test.js
@@ -9,7 +9,6 @@ var Response = require('oauth2-server').Response;
 var Koa = require('koa');
 var request = require('supertest');
 var sinon = require('sinon');
-var Promise = require('bluebird');
 
 /**
  * Test `KoaOAuthServer`.
@@ -32,7 +31,7 @@ describe('KoaOAuthServer', function() {
 
       request(app.listen())
         .get('/')
-        .end(function (err) {
+        .end(function () {
           oauth.server.authenticate.callCount.should.equal(1);
           oauth.server.authenticate.firstCall.args.should.have.length(4);
           oauth.server.authenticate.firstCall.args[0].should.be.an.instanceOf(Request);

--- a/test/unit/index_test.js
+++ b/test/unit/index_test.js
@@ -6,77 +6,87 @@
 var KoaOAuthServer = require('../../');
 var Request = require('oauth2-server').Request;
 var Response = require('oauth2-server').Response;
-var koa = require('koa');
+var Koa = require('koa');
 var request = require('co-supertest');
 var sinon = require('sinon');
+var Promise = require('bluebird');
 
 /**
  * Test `KoaOAuthServer`.
  */
 
-describe.skip('KoaOAuthServer', function() {
+describe('KoaOAuthServer', function() {
   var app;
 
   beforeEach(function() {
-    app = koa();
+    app = new Koa();
   });
 
   describe('authenticate()', function() {
-    it('should call `authenticate()`', function *() {
+    it('should call `authenticate()`', function (done) {
       var oauth = new KoaOAuthServer({ model: {} });
 
-      sinon.stub(oauth.server, 'authenticate').returns({});
+      sinon.stub(oauth.server, 'authenticate').callsArg(3);
 
       app.use(oauth.authenticate());
 
-      yield request(app.listen())
+      request(app.listen())
         .get('/')
-        .end();
+        .end(function (err) {
+          oauth.server.authenticate.callCount.should.equal(1);
+          oauth.server.authenticate.firstCall.args.should.have.length(4);
+          oauth.server.authenticate.firstCall.args[0].should.be.an.instanceOf(Request);
+          oauth.server.authenticate.firstCall.args[3].should.be.an.instanceOf(Function);
+          oauth.server.authenticate.restore();
+          done();
+        });
 
-      oauth.server.authenticate.callCount.should.equal(1);
-      oauth.server.authenticate.firstCall.args.should.have.length(1);
-      oauth.server.authenticate.firstCall.args[0].should.be.an.instanceOf(Request);
-      oauth.server.authenticate.restore();
     });
   });
 
   describe('authorize()', function() {
-    it('should call `authorize()`', function *() {
+    it('should call `authorize()`', function (done) {
       var oauth = new KoaOAuthServer({ model: {} });
 
-      sinon.stub(oauth.server, 'authorize').returns({});
+      sinon.stub(oauth.server, 'authorize').callsArg(3);
 
       app.use(oauth.authorize());
 
-      yield request(app.listen())
+      request(app.listen())
         .get('/')
-        .end();
+        .end(function () {
+          oauth.server.authorize.callCount.should.equal(1);
+          oauth.server.authorize.firstCall.args.should.have.length(4);
+          oauth.server.authorize.firstCall.args[0].should.be.an.instanceOf(Request);
+          oauth.server.authorize.firstCall.args[1].should.be.an.instanceOf(Response);
+          oauth.server.authorize.firstCall.args[3].should.be.an.instanceOf(Function);
+          oauth.server.authorize.restore();
+          done();
+        });
 
-      oauth.server.authorize.callCount.should.equal(1);
-      oauth.server.authorize.firstCall.args.should.have.length(2);
-      oauth.server.authorize.firstCall.args[0].should.be.an.instanceOf(Request);
-      oauth.server.authorize.firstCall.args[1].should.be.an.instanceOf(Response);
-      oauth.server.authorize.restore();
     });
   });
 
   describe('token()', function() {
-    it('should call `token()`', function *() {
+    it('should call `token()`', function (done) {
       var oauth = new KoaOAuthServer({ model: {} });
 
-      sinon.stub(oauth.server, 'token').returns({});
-
+      sinon.stub(oauth.server, 'token').callsArg(3);
+      
       app.use(oauth.token());
 
-      yield request(app.listen())
+      request(app.listen())
         .get('/')
-        .end();
+        .end(function () {
+          oauth.server.token.callCount.should.equal(1);
+          oauth.server.token.firstCall.args.should.have.length(4);
+          oauth.server.token.firstCall.args[0].should.be.an.instanceOf(Request);
+          oauth.server.token.firstCall.args[1].should.be.an.instanceOf(Response);
+          oauth.server.token.firstCall.args[3].should.be.an.instanceOf(Function);
+          oauth.server.token.restore();
+          done();
+        });
 
-      oauth.server.token.callCount.should.equal(1);
-      oauth.server.token.firstCall.args.should.have.length(2);
-      oauth.server.token.firstCall.args[0].should.be.an.instanceOf(Request);
-      oauth.server.token.firstCall.args[1].should.be.an.instanceOf(Response);
-      oauth.server.token.restore();
     });
   });
 });

--- a/test/unit/index_test.js
+++ b/test/unit/index_test.js
@@ -7,7 +7,7 @@ var KoaOAuthServer = require('../../');
 var Request = require('oauth2-server').Request;
 var Response = require('oauth2-server').Response;
 var Koa = require('koa');
-var request = require('co-supertest');
+var request = require('supertest');
 var sinon = require('sinon');
 var Promise = require('bluebird');
 


### PR DESCRIPTION
This PR refactors `koa-oauth-server` to work with the upcoming Koa v2, which has adopted the `async/await` syntax. 

Now, Koa v2 won't be released until `async/await` lands in Node with Node 7 so feel free to simply review this and perhaps create a separate branch for this.